### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   laravel-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Unix-User/PHPMineServerManager/security/code-scanning/4](https://github.com/Unix-User/PHPMineServerManager/security/code-scanning/4)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the permissions required. Based on the workflow's operations, it seems that only `contents: read` is necessary. This will restrict the `GITHUB_TOKEN` to read-only access to the repository contents, ensuring minimal permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
