### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: Notify twitter
 on: [push]
+permissions:
+  contents: read
 jobs:
   setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Unix-User/PHPMineServerManager/security/code-scanning/3](https://github.com/Unix-User/PHPMineServerManager/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow to explicitly define the minimal permissions required. Since the workflow only reads repository metadata (e.g., commit messages, repository URL, and topics), it only needs `contents: read`. No write permissions are required.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
